### PR TITLE
add new features page_section

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+=== 2017-01-24
+* Enhancements
+  * Added new page_section/ page_sections method to accessor
 === Version 1.1.9/2017-01-22
 * Enhancements
   * Populate_page_with now supports radio groups

--- a/features/section.feature
+++ b/features/section.feature
@@ -1,0 +1,128 @@
+Feature: Sections
+
+  Background:
+    Given I am on the section elements page
+
+  Scenario: Getting the text from a section
+    When I get the text from the section
+    Then the text should include "page-object rocks!"
+
+  Scenario: Cannot find elements not in the section
+    When I access an element that is outside of the section
+    Then I should see that is doesn't exist in the section
+
+  Scenario: Finding a link within a section
+    When I search for a link located in a section
+    Then I should be able to click the section link
+
+  Scenario: Finding a button within a section
+    When I search for a button located in a section
+    Then I should be able to click the section button
+
+  Scenario: Finding a text field within a section
+    When I search for a text field located in a section
+    Then I should be able to type "123abc" in the section text field
+
+  Scenario: Finding a hidden field within a section
+    When I search for a hidden field located in a section
+    Then I should be able to see that the section hidden field contains "LeanDog"
+
+  Scenario: Finding a text area within a section
+    When I search for a text area located in a section
+    Then I should be able to type "abcdefg" in the section text area
+
+  Scenario: Finding a select list within a section
+    When I search for a select list located in a section
+    Then I should be able to select "Test 2" in the section select list
+
+  Scenario: Finding a file field within a section
+    When I search for a file field located in a section
+    Then I should be able to set the section file field
+
+  Scenario: Finding a checkbox within a section
+    When I search for a checkbox located in a section
+    Then I should be able to check the section checkbox
+
+  Scenario: Finding a radio button witin a section
+    When I search for a radio button located in a section
+    Then I should be able to select the section radio button
+
+  Scenario: Finding a div within a section
+    When I search for a div located in a section
+    Then I should see the text "page-object rocks!" in the section div
+
+  Scenario: Finding a span within a section
+    When I search for a span located in a section
+    Then I should see the text "My alert" in the section span
+
+  Scenario: Finding a table within a section
+    When I search for a table located in a section
+    Then the data for row "1" of the section table should be "Data1" and "Data2"
+
+  Scenario: Finding a table cell within a section
+    When I search the second table cell located in a table in a section
+    Then the section table cell should contain "Data2"
+
+  Scenario: Finding an image within a section
+    When I search for an image located in a section
+    Then the section image should be "106" pixels wide
+    And the section image should be "106" pixels tall
+
+  Scenario: Finding a form within a section
+    When I search for a form located in a section
+    Then I should be able to submit the section form
+
+  Scenario: Finding an ordered list within a section
+    When I search for an ordered list located in a section
+    Then the first section list items text should be "Number One"
+
+  Scenario: Finding an unordered list within a section
+    When I search for an unordered list located in a section
+    Then the first section list items text should be "Item One"
+
+  Scenario: Finding a list item section in an ordered list within a section
+    When I search for a list item section in an ordered list in a section
+    Then I should see the section list items text should be "Number One"
+
+  Scenario: Finding a h1 within a section
+    When I search for a h1 located in a section
+    Then I should see the section h1s text should be "h1's are cool"
+
+  Scenario: Finding a h2 within a section
+    When I search for a h2 located in a section
+    Then I should see the section h2s text should be "h2's are cool"
+
+  Scenario: Finding a h3 within a section
+    When I search for a h3 located in a section
+    Then I should see the section h3s text should be "h3's are cool"
+
+  Scenario: Finding a h4 within a section
+    When I search for a h4 located in a section
+    Then I should see the section h4s text should be "h4's are cool"
+
+  Scenario: Finding a h5 within a section
+    When I search for a h5 located in a section
+    Then I should see the section h5s text should be "h5's are cool"
+
+  Scenario: Finding a h6 within a section
+    When I search for a h6 located in a section
+    Then I should see the section h6s text should be "h6's are cool"
+
+  Scenario: Finding a paragraph within a section
+    When I search for a paragraph located in a section
+    Then I should see the section paragraphs text should be "This is a paragraph."
+
+  Scenario: Selecting multiple sections
+    When I select multiple sections
+    Then I should have a section collection containing the sections
+    And I can access any index of that collection of sections
+
+  Scenario: Searching section collection
+    Given I select multiple sections
+    When I search by a specific value of the section
+    Then I will find the first section with that value
+
+  Scenario: Filtering section collection
+    Given I select multiple sections
+    When I filter by a specific value of the sections
+    Then I will find all sections with that value

--- a/features/step_definations/section_steps.rb
+++ b/features/step_definations/section_steps.rb
@@ -1,0 +1,262 @@
+class Container
+  include Druid
+
+  link(:section_link)
+  button(:section_button)
+  text_field(:section_text_field)
+  hidden_field(:section_hidden_field)
+  text_area(:section_text_area)
+  select_list(:section_select_list)
+  file_field(:section_file_field)
+  checkbox(:section_checkbox)
+  radio_button(:section_radio_button)
+  div(:section_div)
+  span(:section_span)
+  table(:section_table)
+  cell(:section_cell) { |page| page.section_table_element.cell_element(:index => 1) }
+  image(:section_image)
+  form(:section_form)
+  ordered_list(:section_ordered_list)
+  unordered_list(:section_unordered_list)
+  list_item(:section_list_item) { |page| page.section_ordered_list_element.list_item_element }
+  h1(:section_h1)
+  h2(:section_h2)
+  h3(:section_h3)
+  h4(:section_h4)
+  h5(:section_h5)
+  h6(:section_h6)
+  paragraph(:section_paragraph)
+
+  unordered_list(:outside_section, :id => 'outer')
+end
+
+class InputSection
+  include Druid
+
+  def value
+    root.value
+  end
+end
+
+class SectionElementsPage
+  include Druid
+
+  page_section(:container, Container, :id => 'div_id')
+  page_sections(:page_inputs, InputSection, :tag_name => 'input')
+
+end
+Given(/^I am on the section elements page$/) do
+  @page = SectionElementsPage.new(@driver)
+  @page.navigate_to(UrlHelper.nested_elements)
+end
+
+When(/^I get the text from the section$/) do
+  @text = @page.container.text
+end
+
+Then(/^the text should include "([^"]*)"$/) do |expected_text|
+  expect(@text).to include expected_text
+end
+
+When(/^I access an element that is outside of the section$/) do
+  @element = @page.container.outside_section_element
+end
+
+Then(/^I should see that is doesn't exist in the section$/) do
+  expect(@element).not_to exist
+end
+
+When(/^I search for a link located in a section$/) do
+  @link = @page.container.section_link_element
+end
+
+Then(/^I should be able to click the section link$/) do
+  @link.click
+end
+
+When(/^I search for a button located in a section$/) do
+  @button = @page.container.section_button_element
+end
+
+Then(/^I should be able to click the section button$/) do
+  @button.click
+end
+
+When(/^I search for a text field located in a section$/) do
+  @text_field = @page.container.section_text_field_element
+end
+
+Then(/^I should be able to type "([^"]*)" in the section text field$/) do |value|
+  @text_field.value = value
+end
+
+When(/^I search for a hidden field located in a section$/) do
+  @hidden_field = @page.container.section_hidden_field_element
+end
+
+Then(/^I should be able to see that the section hidden field contains "([^"]*)"$/) do |value|
+  expect(@hidden_field.value).to eql value
+end
+
+When(/^I search for a text area located in a section$/) do
+  @text_area = @page.container.section_text_area_element
+end
+
+Then(/^I should be able to type "([^"]*)" in the section text area$/) do |value|
+  @text_area.value = value
+end
+
+When(/^I search for a select list located in a section$/) do
+  @select_list = @page.container.section_select_list_element
+end
+
+Then(/^I should be able to select "([^"]*)" in the section select list$/) do |value|
+  @select_list.select value
+end
+
+When(/^I search for a file field located in a section$/) do
+  @ff = @page.container.section_file_field_element
+end
+
+Then(/^I should be able to set the section file field$/) do
+  @ff.value = __FILE__
+end
+
+When(/^I search for a checkbox located in a section$/) do
+  @checkbox = @page.container.section_checkbox_element
+end
+
+Then(/^I should be able to check the section checkbox$/) do
+  @checkbox.check
+end
+
+When(/^I search for a radio button located in a section$/) do
+  @radio = @page.container.section_radio_button_element
+end
+
+Then(/^I should be able to select the section radio button$/) do
+  @radio.select
+end
+
+When(/^I search for a div located in a section$/) do
+  @div = @page.container.section_div_element
+end
+
+Then(/^I should see the text "([^"]*)" in the section div$/) do |value|
+  expect(@div.text).to eql value
+end
+
+When(/^I search for a span located in a section$/) do
+  @span = @page.container.section_span_element
+end
+
+Then(/^I should see the text "([^"]*)" in the section span$/) do |value|
+  expect(@span.text).to eql value
+end
+
+When(/^I search for a table located in a section$/) do
+  @table = @page.container.section_table_element
+end
+
+Then(/^the data for row "([^"]*)" of the section table should be "([^"]*)" and "([^"]*)"$/) do |row, col1, col2|
+  table_row = @table[row.to_i - 1]
+  expect(table_row[0].text).to eql col1
+  expect(table_row[1].text).to eql col2
+end
+
+When(/^I search the second table cell located in a table in a section$/) do
+  @cell = @page.container.section_cell_element
+end
+
+Then(/^the section table cell should contain "([^"]*)"$/) do |value|
+  expect(@cell.text).to eql value
+end
+
+When(/^I search for an image located in a section$/) do
+  @image = @page.container.section_image_element
+end
+
+Then(/^the section image should be "([^"]*)" pixels wide$/) do |width|
+  expect(@image.width).to eql width.to_i
+end
+
+Then(/^the section image should be "([^"]*)" pixels tall$/) do |height|
+  expect(@image.height).to eql height.to_i
+end
+
+When(/^I search for a form located in a section$/) do
+  @form = @page.container.section_form_element
+end
+
+Then(/^I should be able to submit the section form$/) do
+  @form.submit
+end
+
+When(/^I search for an ordered list located in a section$/) do
+  @list = @page.container.section_ordered_list_element
+end
+
+Then(/^the first section list items text should be "([^"]*)"$/) do |value|
+  expect(@list[0].text).to eql value
+end
+
+When(/^I search for an unordered list located in a section$/) do
+  @list = @page.container.section_unordered_list_element
+end
+
+When(/^I search for a list item section in an ordered list in a section$/) do
+  @li = @page.container.section_list_item_element
+end
+
+Then(/^I should see the section list items text should be "([^"]*)"$/) do |value|
+  expect(@li.text).to eql value
+end
+
+When(/^I search for a h(\d+) located in a section$/) do |num|
+  @header = @page.container.send "section_h#{num}_element"
+end
+
+Then(/^I should see the section h(\d+)s text should be "([^"]*)"$/) do |num, value|
+  expect(@header.text).to eql value
+end
+
+When(/^I search for a paragraph located in a section$/) do
+  @paragraph = @page.container.section_paragraph_element
+end
+
+Then(/^I should see the section paragraphs text should be "([^"]*)"$/) do |value|
+  expect(@paragraph.text).to eql value
+end
+
+When(/^I select multiple sections$/) do
+  @sections = @page.page_inputs
+end
+
+Then(/^I should have a section collection containing the sections$/) do
+  expect(@sections).to be_instance_of Druid::SectionCollection
+end
+
+Then(/^I can access any index of that collection of sections$/) do
+  expect(@sections[0]).to be_a(Druid)
+  expect(@sections[-1]).to be_a(Druid)
+end
+
+When(/^I search by a specific value of the section$/) do
+  @element = @sections.find_by(:value => 'LeanDog')
+end
+
+Then(/^I will find the first section with that value$/) do
+  expect(@element).to be_a(Druid)
+  expect(@element.value). to eq 'LeanDog'
+end
+
+When(/^I filter by a specific value of the sections$/) do
+  @elements = @sections.select_by(:value => /\w+/)
+end
+
+Then(/^I will find all sections with that value$/) do
+  expect(@elements).to be_a Druid::SectionCollection
+  @elements.map(&:value).each do |element|
+    expect(element).to match(/\w+/)
+  end
+end

--- a/lib/druid.rb
+++ b/lib/druid.rb
@@ -60,12 +60,9 @@ module Druid
   end
 
   def initialize_driver root
-    if root.is_a? Watir::HTMLElement || root.is_a?(Watir::Browser)
-      @root_element = Elements::Element.new root
-      @driver = root
-    else
-      raise ArgumentError, "expect Watir::Browser or Watir::HTMLElement"
-    end
+    @driver = root if root.is_a? Watir::HTMLElement or root.is_a? Watir::Browser
+    @root_element = Elements::Element.new root if root.is_a? Watir::HTMLElement
+    raise "expect Watir::Browser or Watir::HTMLElement" if not root.is_a? Watir::HTMLElement and not root.is_a? Watir::Browser
   end
 
   # @private
@@ -422,7 +419,7 @@ module Druid
   private
 
   def root
-    @root_element
+    @root_element || driver
   end
 
 end

--- a/lib/druid/accessors.rb
+++ b/lib/druid/accessors.rb
@@ -1189,6 +1189,54 @@ module Druid
     end
 
     #
+    # adds a method to return a page object rooted at the element
+    #
+    # @example
+    #   page_section(:navigation_bar, NavigationBar, :id => 'nav-bar')
+    #   # will generate 'navigation_bar'
+    #
+    # @param [Symbol] the name used for the generated methods
+    # @param [Class] the class to instantiate for the element
+    # @param [Hash] identifier how we find an element. You can use multiple parameters
+    #   by combining of any of the following except xpath. The valid keys are:
+    #   * :class
+    #   * :css
+    #   * :id
+    #   * :index
+    #   * :name
+    #   * :xpath
+    #
+    def page_section(name, section_class, identifier)
+      define_method(name) do
+        page_for(identifier, section_class)
+      end
+    end
+
+    #
+    # adds a method to return a collection of page objects rooted at elements
+    #
+    # @example
+    #   page_sections(:articles, Article, :class => 'article')
+    #   # will generate 'articles'
+    #
+    # @param [Symbol] the name used for the generated method
+    # @param [Class] the class to instantiate for each element
+    # @param [Hash] identifier how we find an element. You can use a multiple parameters
+    #   by combining of any of the following except xpath. The valid keys are:
+    #   * :class
+    #   * :css
+    #   * :id
+    #   * :index
+    #   * :name
+    #   * :xpath
+    #
+    def page_sections(name, section_class, identifier)
+      define_method(name) do
+        pages_for(identifier, section_class)
+      end
+    end
+
+    #
     # methods to generate accessors for types that follow the same
     # pattern as element
     #

--- a/lib/druid/assist.rb
+++ b/lib/druid/assist.rb
@@ -522,6 +522,20 @@ module Druid
       find_elements("bs(identifier)", Elements::Bold, identifier, 'b')
     end
 
+    #
+    # method to return a Druid rooted at an element
+    #
+    def page_for(identifier, section_class)
+      find_page(identifier, section_class)
+    end
+
+    #
+    # method to return a collection of Druids rooted at elements
+    #
+    def pages_for(identifier, section_class)
+      SectionCollection.new(find_pages(identifier, section_class))
+    end
+
     private
 
     def find_elements(the_call, type, identifier, tag_name=nil)
@@ -536,6 +550,20 @@ module Druid
       element = driver.instance_eval "#{nested_frames(frame_identifiers)}#{the_call}"
       switch_to_default_content(frame_identifiers)
       type.new(element)
+    end
+
+    def find_pages(identifier, section_class)
+      identifier, frame_identifiers = parse_identifiers(identifier, Elements::Element, 'element')
+      elements = driver.instance_eval "#{nested_frames(frame_identifiers)}elements(identifier)"
+      switch_to_default_content(frame_identifiers)
+      elements.map { |element| section_class.new(element) }
+    end
+
+    def find_page(identifier, section_class)
+      identifier, frame_identifiers = parse_identifiers(identifier, Elements::Element, 'element')
+      element = driver.instance_eval "#{nested_frames(frame_identifiers)}element(identifier)"
+      switch_to_default_content(frame_identifiers)
+      section_class.new(element)
     end
 
     def process_call(the_call, type, identifier, value=nil, tag_name=nil)

--- a/lib/druid/sections.rb
+++ b/lib/druid/sections.rb
@@ -1,0 +1,29 @@
+module Druid
+  class SectionCollection
+    include Enumerable
+
+    def initialize sections
+      @sections = sections
+    end
+
+    def each &block
+      @sections.each &block
+    end
+
+    def [] index
+      @sections[index]
+    end
+
+    def find_by values_hash
+      @sections.find { |section|
+        values_hash.all? { |key, value| value === section.public_send(key) }
+      }
+    end
+
+    def select_by values_hash
+      SectionCollection.new @sections.select { |section|
+        values_hash.all? { |key, value| value === section.public_send(key) }
+      }
+    end
+  end
+end

--- a/spec/druid/druid_spec.rb
+++ b/spec/druid/druid_spec.rb
@@ -80,7 +80,7 @@ describe Druid do
     it "should throw an error" do
       expect {
         TestDruid.new("blah")
-      }.to raise_error 'expect Watir::Browser'
+      }.to raise_error 'expect Watir::Browser or Watir::HTMLElement'
     end
   end
 

--- a/spec/druid/druid_spec.rb
+++ b/spec/druid/druid_spec.rb
@@ -88,6 +88,7 @@ describe Druid do
     context "when using PageObject" do
 
       it "should display the page text" do
+        # expect(driver).to receive(:element).and_return(driver)
         expect(driver).to receive(:text).and_return("driver text")
         expect(druid.text).to eql "driver text"
       end

--- a/spec/druid/page_section_spec.rb
+++ b/spec/druid/page_section_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+class Container
+  include Druid
+end
+
+class SectionsPage
+  include Druid
+
+  page_section(:container, Container, :id => 'blah')
+  page_sections(:containers, Container, :class => 'foo')
+end
+
+describe Druid::Accessors do
+  context "when using watir" do
+    let(:driver) { mock_driver }
+    let(:druid) { SectionsPage.new(driver) }
+
+    it "it should find a page section" do
+      expect(driver).to receive(:element).with(:id => 'blah').and_return(driver)
+      section = druid.container
+      expect(section).to be_instance_of Container
+    end
+
+    it "it should find page sections" do
+      expect(driver).to receive(:elements).with(:class => 'foo').and_return([driver, driver])
+      sections = druid.containers
+      expect(sections).to be_instance_of Druid::SectionCollection
+      sections.each do |section|
+        expect(section).to be_instance_of Container
+      end
+    end
+  end
+
+  describe Druid::SectionCollection do
+    ContainedItem = Struct.new(:type, :name)
+    let(:section_collection) do
+      contained_items = [ContainedItem.new(:sandwich, :reuben), ContainedItem.new(:soup, :lobstar_bisque), ContainedItem.new(:sandwich, :dagwood)]
+      Druid::SectionCollection.new(contained_items)
+    end
+
+    it "should be indexed to the sections" do
+      expect(section_collection[0]).to be_an_instance_of ContainedItem
+      expect(section_collection[-1]).to be_an_instance_of ContainedItem
+    end
+
+    it "should be able to iterate over the sections" do
+      section_collection.each do |section|
+        expect(section).to be_an_instance_of ContainedItem
+      end
+    end
+
+    it "should find a section by one of its values" do
+      expect(section_collection.find_by(name: :dagwood).name).to eq :dagwood
+    end
+
+    it "should find all sections matching a value" do
+      expect(section_collection.select_by(type: :sandwich).map(&:type)).to eq [:sandwich, :sandwich]
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "watir-webdriver"
 
 def mock_driver
   driver = double('watir')
+  allow(driver).to receive(:is_a?).with(anything()).and_return(true)
   allow(driver).to receive(:is_a?).with(Watir::Browser).and_return(true)
   driver
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require "watir-webdriver"
 
 def mock_driver
   driver = double('watir')
-  allow(driver).to receive(:is_a?).with(anything()).and_return(true)
+  allow(driver).to receive(:is_a?).with(anything()).and_return(false)
   allow(driver).to receive(:is_a?).with(Watir::Browser).and_return(true)
   driver
 end


### PR DESCRIPTION
At the heart of it, page sections make it so that you can narrow the focus of a page object to a specific element on the page and its children. This makes identifying important elements easier because we will never accidentally pick up elements outside the scope we are looking in.

The largest value provided is when working with a page with many behaviors and functionalities. To reason about this, I'm going to use the following example 

There are two main ways sections add value. Breaking down large conceptual areas, and representing collections of related elements.

Breaking Down Large Conceptual Areas

On any given page of search results on amazon, you have a few different areas of concern:

Search results
Filters on the results
Menus and Navigation
Search and sort bars

This is more complex than some websites, but still less complex than some websites I've worked on.

Now we could put all these concerns into one page object but the number of methods grows a lot. We can break it up into modules based on these areas, but at the end of the day, including all these modules in one place means the instantiated object has the same number of methods, and we have just as much risk, if not more, of having collisions between method names. We could make separate page objects for each section, but it sounds hacky with the DSL and can lead to some ugly code. For example if I have these page objects for the areas of the page:

```
class SearchBar
  include Druid

  text_field(:bar)  # if it's the only text field in the section we don't need to identify it
  button(:go) # if we are not using page sections, the search is within the whole page

  def for search_term
    bar = search_term
    go
  end
end

class Filters
  include Druid
  link(:prime_eligible, id: 'whatever_id')
end
```
Then I can currently use them together using a page object like this:

```
class SearchPage
  include Druid

  # whatever elements needed for reasoning about search results
end

on SearchBar do |page|
  page.search_for 'ruby books'
end
on Filters do |page|
  page.check_prime_eligible
end
on SearchResults do |page|
  # verify results are all prime eligible
end
```
Or by treating each area as a section, I can put it together on one page but with encapsulation like the separate pages:

```
class SearchPage
  include Druid

  page_section(:search, SearchBar, id: 'search_bar_section')
  page_section(:filters, Filters, id: 'filters_section')

  # whatever elements needed for reasoning about search results
end

on SearchPage do |page|
  page.search.for 'ruby books'
  page.filters.check_prime_eligible
  # verify results are all prime eligible
end
```
Yes, the code for setup is longer, but the code of use is shorter and cleaner. If I could choose to have to do more thinking in my implementation of hitting the page, or in my test that is hitting the page to test something, I would choose in the implementation every time.

Representing Collections of Related Elements

Having a collection of page sections makes dealing with multiple collections of related elements far easier. To demonstrate, I'm going to talk about amazon again. 

Probably a cleaner approach is using collections of elements:

```
class SearchPage
  include Druid

  links(:name, id: /^search_result_name_[\d+]$/)
  images(:prime_icon, id: /^search_result_prime_[\d+]$/)
end
```
Using collections like this, I can find the index of a result with a specific name, and use that index for other collections, but depending on how the prime eligibility images are set up, I might not be able to link it up to results 1 to 1. I can reason about the whole collection of any 1 piece, but if any element happens on some results, but not others, I lose a lot of information.

If I want to use sections:

```
class SearchPage
  include Druid

  page_sections(:results, SearchResult, class: 'search_result')
end

class SearchResult
  include Druid

  link(:name, id: /^search_result_name_[\d+]$/)
  image(:prime_icon, id: /^search_result_prime_[\d+]$/)

  def prime_eligible?
    prime_icon_element.visible?
  end
end
```
I can reason about the set of results and ask about each one. Further, I can define specific methods to reason about a section further:

```
on SearchPage do |page|
  page.results.each do |result|
    expect(result.prime_eligible?).to be true
  end
  # or shorter still expect(page.results).to all(be_prime_eligible)
end
```
Because the collections are enumerable, we have the full power of the enumerable methods to help us process and reason about the data. This becomes even more important when we have collections within collections. Because each section scopes at a specific element, we can never accidentally identify the elements from another section. For example, if search results also had inline reviews listed, I could ask for page.results[0].reviews, and know I'm only getting reviews from inside the first result.