### PR TITLE
make druid support return cookies object and use all methods on cooki…

### DIFF
--- a/lib/druid.rb
+++ b/lib/druid.rb
@@ -371,7 +371,7 @@ module Druid
   end
 
   #
-  # Handles cookies
+  # Handle cookies
   #
   # @return [Watir::Cookies]
   #

--- a/lib/druid.rb
+++ b/lib/druid.rb
@@ -371,10 +371,12 @@ module Druid
   end
 
   #
-  # Clear the cookies from the browser
+  # Handles cookies
   #
-  def clear_cookies
-    driver.cookies.clear
+  # @return [Watir::Cookies]
+  #
+  def cookies
+    driver.cookies
   end
 
   #

--- a/spec/druid/druid_spec.rb
+++ b/spec/druid/druid_spec.rb
@@ -256,10 +256,9 @@ describe Druid do
         druid.modal_dialog {}
       end
 
-      it "should know how to clear all of the cookies from the browser" do
-        expect(driver).to receive(:cookies).and_return(driver)
-        expect(driver).to receive(:clear)
-        druid.clear_cookies
+      it "should know how to handle cookies" do
+        expect(driver).to receive(:cookies).and_return([])
+        druid.cookies
       end
 
       it "should be able to save a screenshot" do


### PR DESCRIPTION
now page.cookies will return Watir::Cookies object, and all methods on Watir::Cookies class are available. e.g:
page.cookies.to_a
page.cookies[:my_session]
page.cookies.add 'my_session', 'BAh7B0kiD3Nlc3Npb25faWQGOgZFRkk', secure: true
page.cookies.delete 'my_session'
page.cookies.clear
etc:
more details you wanted to refer to -----> https://github.com/watir/watir/blob/99b5d467de5022d6985a6a494b408fa561da0f2c/lib/watir/cookies.rb