### PR TITLE
allow filling forms with any object that can be converted to a Hash

### DIFF
--- a/lib/druid/page_populator.rb
+++ b/lib/druid/page_populator.rb
@@ -29,8 +29,8 @@ module Druid
     # false for a Checkbox or RadioButton.
     #
     def populate_page_with(data)
-      data.each do |key, value|
-        populate_section(key, value) if value.is_a?(Hash)
+      data.to_h.each do |key, value|
+        populate_section(key, value) if value.respond_to?(:to_h)
         populate_value(self, key, value)
       end
     end
@@ -39,7 +39,7 @@ module Druid
 
     def populate_section(section, data)
       return unless self.respond_to? section
-      data.each do |key, value|
+      data.to_h.each do |key, value|
         populate_value(self.send(section), key, value)
       end
     end

--- a/spec/druid/page_populator_spec.rb
+++ b/spec/druid/page_populator_spec.rb
@@ -23,6 +23,15 @@ describe Druid::PagePopulator do
   let(:driver) { mock_driver }
   let(:druid) { DruidPagePopulator.new(driver) }
 
+  it "should accept any object that can be converted to a Hash" do
+    os = OpenStruct.new('tf' => 'value', 'sl' => 'value')
+    expect(druid).to receive(:tf=).with('value')
+    expect(druid).to receive(:sl=).with('value')
+
+    allow(druid).to receive(:is_enabled?).and_return(true)
+    druid.populate_page_with(os)
+  end
+
   it "should set a value in a text field" do
     expect(druid).to receive(:tf=).with('value')
     expect(druid).to receive(:is_enabled?).and_return(true)
@@ -137,6 +146,15 @@ describe Druid::PagePopulator do
       expect(section).to receive(:stf=).with('value')
       expect(druid).to receive(:is_enabled?).and_return(true)
       druid.populate_page_with('section' => {'stf' => 'value'})
+    end
+
+    it "populate a page section when the value repsonds to #to_h and it exists" do
+      os = OpenStruct.new('tf' => 'value', 'sl' => 'value')
+      expect(section).to receive(:tf=).with('value')
+      expect(section).to receive(:sl=).with('value')
+
+      allow(druid).to receive(:is_enabled?).twice.and_return(true)
+      druid.populate_page_with('section' => os)
     end
 
     it "should not set a value in a text field if it is not found on the page" do


### PR DESCRIPTION
This allows passing in more structured data forms than just Hashes (like OpenStruct, Struct, etc)

